### PR TITLE
Image Fix for .io Page

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,4 +71,4 @@ The SDR relay breakout integrates a high-ampacity mechanical relay with a termin
 ##### *HLK-PM01 Breakout*
 The HLK-PM01 forms the necessary AC/DC rectifying and buffering to provide 5v power to the MYBUTLER system. Each unit can provide up to 600ma of continuous current, and the system is self-contained and UL certified. The breakout for this board only provides a buffering capacitor and trace-routing to allow for a small fanout from the unit's pins to the MYBUTLER system's power wiring.
 
-[logo]: /Documentation/GHPages/MYBUTLER.png "MYBUTLER"
+[logo]:/Documentation/GHPages/MYBUTLER.png?raw=true "MYBUTLER"


### PR DESCRIPTION
Our GitHub Page, found [HERE](https://csumb-sp17-cst499.github.io/MYBUTLER/), is not displaying the logo correctly. This is not good.

Feel free to approve when:
- [x] One person looks at it and has a second to push the PR Accept button
- [x] No one else objects, yet