### PR TITLE
Scripting

### DIFF
--- a/Software/Configuration/openhab2.service
+++ b/Software/Configuration/openhab2.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=The openHAB 2 Home Automation Bus Solution
+Documentation=http://docs.openhab.org
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+User=openhab
+Group=openhab
+GuessMainPID=yes
+WorkingDirectory=/opt/openhab2
+#EnvironmentFile=/etc/default/openhab2
+ExecStart=/opt/openhab2/start.sh server
+ExecStop=/bin/kill -SIGINT $MAINPID
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/Software/Tools/enableOH2.sh
+++ b/Software/Tools/enableOH2.sh
@@ -1,0 +1,32 @@
+#! /bin/bash
+
+# GO HOME
+USER_HOME=$(getent passwd $SUDO_USER | cut -d: -f6)
+cd $USER_HOME
+
+
+# INSTALLING OH2 SERVICE
+echo ""
+echo ""
+echo "  --> *INSTALLING SERVICE FILE*"
+echo ""
+sudo cp $USER_HOME/MYBUTLER/Software/Configuration/openhab.service /lib/systemd/system/openhab2.service
+echo ""
+
+# CONFIGURING LINUX TO START OH2
+echo ""
+echo ""
+echo "  ---> *ENABLING OpenHAB 2 AS SERVICE*"
+echo ""
+sudo systemctl daemon-reload
+sudo systemctl enable openhab2.service
+echo ""
+
+# CONFIGURING PM2 TO START AT RUNTIME
+echo ""
+echo ""
+echo "  --> *STARTING AND CHECKING SERVICE*"
+echo ""
+sudo systemctl start openhab2.service
+sudo systemctl status openhab2.service
+echo ""

--- a/Software/Tools/enableOH2.sh
+++ b/Software/Tools/enableOH2.sh
@@ -10,7 +10,7 @@ echo ""
 echo ""
 echo "  --> *INSTALLING SERVICE FILE*"
 echo ""
-sudo cp $USER_HOME/MYBUTLER/Software/Configuration/openhab.service /lib/systemd/system/openhab2.service
+sudo cp $USER_HOME/MYBUTLER/Software/Configuration/openhab2.service /lib/systemd/system/openhab2.service
 echo ""
 
 # CONFIGURING LINUX TO START OH2

--- a/Software/Tools/enableOH2.sh
+++ b/Software/Tools/enableOH2.sh
@@ -5,7 +5,7 @@ USER_HOME=$(getent passwd $SUDO_USER | cut -d: -f6)
 cd $USER_HOME
 
 
-# INSTALLING OH2 SERVICE
+# INSTALLING OpenHAB 2 SERVICE
 echo ""
 echo ""
 echo "  --> *INSTALLING SERVICE FILE*"
@@ -13,7 +13,7 @@ echo ""
 sudo cp $USER_HOME/MYBUTLER/Software/Configuration/openhab2.service /lib/systemd/system/openhab2.service
 echo ""
 
-# CONFIGURING LINUX TO START OH2
+# CONFIGURING LINUX TO START OpenHAB 2 AT BOOT
 echo ""
 echo ""
 echo "  ---> *ENABLING OpenHAB 2 AS SERVICE*"
@@ -22,7 +22,7 @@ sudo systemctl daemon-reload
 sudo systemctl enable openhab2.service
 echo ""
 
-# CONFIGURING PM2 TO START AT RUNTIME
+# CHECKING STATUS OF OpenHAB 2 RUNTIME
 echo ""
 echo ""
 echo "  --> *STARTING AND CHECKING SERVICE*"


### PR DESCRIPTION
This adds a function to enable OpenHAB2 as a startup service on the Pi.

Any team member can review and approve - this was copied directly from the OpenHAB site and worked for me after typo fix, with no other changes.